### PR TITLE
selective_cache_purge_response_maxlines parameter added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ An example:
 
         selective_cache_purge_redis_database 1;
 
+        selective_cache_purge_response_maxlines 100;
+
         server {
             listen          8080;
             server_name     localhost;

--- a/include/ngx_selective_cache_purge_module.h
+++ b/include/ngx_selective_cache_purge_module.h
@@ -28,6 +28,7 @@ typedef struct {
     ngx_uint_t                redis_port;
     ngx_uint_t                redis_database;
     ngx_uint_t                response_maxlines;
+    ngx_uint_t                keep_opened_files;
 } ngx_selective_cache_purge_main_conf_t;
 
 typedef struct {

--- a/include/ngx_selective_cache_purge_module.h
+++ b/include/ngx_selective_cache_purge_module.h
@@ -27,6 +27,7 @@ typedef struct {
     ngx_str_t                 redis_host;
     ngx_uint_t                redis_port;
     ngx_uint_t                redis_database;
+    ngx_uint_t                response_maxlines;
 } ngx_selective_cache_purge_main_conf_t;
 
 typedef struct {

--- a/nginx.conf
+++ b/nginx.conf
@@ -32,6 +32,7 @@ http {
     selective_cache_purge_redis_host localhost;
     selective_cache_purge_redis_port 6379;
     selective_cache_purge_redis_database 4;
+    selective_cache_purge_response_maxlines 100;
 
     server {
         listen          8080;

--- a/src/ngx_selective_cache_purge_module.c
+++ b/src/ngx_selective_cache_purge_module.c
@@ -226,19 +226,17 @@ ngx_selective_cache_purge_send_purge_response(void *d)
         for (cur = ngx_queue_head(&ctx->db_ctx->entries); cur != ngx_queue_sentinel(&ctx->db_ctx->entries); cur = ngx_queue_next(cur)) {
             entry = ngx_queue_data(cur, ngx_selective_cache_purge_cache_item_t, queue);
             if (entry->removed) {
-
-                if (++passed > maxlines) {
-                    if (passed == maxlines + 1)
-                        ngx_selective_cache_purge_send_response_text(r, SKIP_REST_MESSAGE.data, SKIP_REST_MESSAGE.len, 0);
-                    continue;
-                }
-
                 ngx_selective_cache_purge_send_response_text(r, entry->cache_key->data, entry->cache_key->len, 0);
                 ngx_selective_cache_purge_send_response_text(r, CACHE_KEY_FILENAME_SEPARATOR.data, CACHE_KEY_FILENAME_SEPARATOR.len, 0);
 
                 ngx_selective_cache_purge_send_response_text(r, entry->path->data, entry->path->len, 0);
                 ngx_selective_cache_purge_send_response_text(r, entry->filename->data, entry->filename->len, 0);
                 ngx_selective_cache_purge_send_response_text(r, LF_SEPARATOR.data, LF_SEPARATOR.len, 0);
+
+                if (++passed == maxlines) {
+                    ngx_selective_cache_purge_send_response_text(r, SKIP_REST_MESSAGE.data, SKIP_REST_MESSAGE.len, 0);
+                    break;
+                }
             }
         }
 

--- a/src/ngx_selective_cache_purge_module_setup.c
+++ b/src/ngx_selective_cache_purge_module_setup.c
@@ -50,6 +50,12 @@ static ngx_command_t  ngx_selective_cache_purge_commands[] = {
       NGX_HTTP_MAIN_CONF_OFFSET,
       offsetof(ngx_selective_cache_purge_main_conf_t, response_maxlines),
       NULL },
+    { ngx_string("selective_cache_purge_keep_opened_files"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_selective_cache_purge_main_conf_t, keep_opened_files),
+      NULL },
     { ngx_string("selective_cache_purge_query"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_selective_cache_purge,
@@ -105,6 +111,7 @@ ngx_selective_cache_purge_create_main_conf(ngx_conf_t *cf)
     conf->redis_port = NGX_CONF_UNSET_UINT;
     conf->redis_database = NGX_CONF_UNSET_UINT;
     conf->response_maxlines = NGX_CONF_UNSET_UINT;
+    conf->keep_opened_files = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -135,6 +142,7 @@ ngx_selective_cache_purge_init_main_conf(ngx_conf_t *cf, void *parent)
     ngx_conf_merge_uint_value(conf->redis_port, conf->redis_port, 6379);
     ngx_conf_merge_uint_value(conf->redis_database, conf->redis_database, 0);
     ngx_conf_merge_uint_value(conf->response_maxlines, conf->response_maxlines, NGX_MAX_INT_T_VALUE);
+    ngx_conf_merge_uint_value(conf->keep_opened_files, conf->keep_opened_files, NGX_MAX_INT_T_VALUE);
 #endif
 
     return NGX_CONF_OK;

--- a/src/ngx_selective_cache_purge_module_setup.c
+++ b/src/ngx_selective_cache_purge_module_setup.c
@@ -44,6 +44,12 @@ static ngx_command_t  ngx_selective_cache_purge_commands[] = {
       NGX_HTTP_MAIN_CONF_OFFSET,
       offsetof(ngx_selective_cache_purge_main_conf_t, redis_database),
       NULL },
+    { ngx_string("selective_cache_purge_response_maxlines"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_selective_cache_purge_main_conf_t, response_maxlines),
+      NULL },
     { ngx_string("selective_cache_purge_query"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_selective_cache_purge,
@@ -98,6 +104,7 @@ ngx_selective_cache_purge_create_main_conf(ngx_conf_t *cf)
     conf->redis_host.data = NULL;
     conf->redis_port = NGX_CONF_UNSET_UINT;
     conf->redis_database = NGX_CONF_UNSET_UINT;
+    conf->response_maxlines = NGX_CONF_UNSET_UINT;
 
     return conf;
 }
@@ -127,6 +134,7 @@ ngx_selective_cache_purge_init_main_conf(ngx_conf_t *cf, void *parent)
 
     ngx_conf_merge_uint_value(conf->redis_port, conf->redis_port, 6379);
     ngx_conf_merge_uint_value(conf->redis_database, conf->redis_database, 0);
+    ngx_conf_merge_uint_value(conf->response_maxlines, conf->response_maxlines, NGX_MAX_INT_T_VALUE);
 #endif
 
     return NGX_CONF_OK;


### PR DESCRIPTION
New **selective_cache_purge_response_maxlines** parameter:
1. Reduces response size and increases performance when we don't need detailed report.
2. Workarounds #7
